### PR TITLE
bug fix on stroke processing

### DIFF
--- a/tanglism-morph/src/stroke.rs
+++ b/tanglism-morph/src/stroke.rs
@@ -55,13 +55,13 @@ impl<'p, 't, T: TradingTimestamps> StrokeShaper<'p, 't, T> {
     fn consume(&mut self, pt: Parting) {
         // 存在前一笔时，比较当前的分型是否与前一笔的终点分型类型一致
         // 如果一致，则比较高低，并根据情况修改笔或丢弃
-        if let Some(sk) = self.sks.last_mut() {
+        if let Some(sk) = self.sks.last() {
             // 比较方向
             if sk.end_pt.top == pt.top {
                 // 顶比前顶高，或者底比前底低，直接修改该笔
                 if (pt.top && pt.extremum_price > sk.end_pt.extremum_price) || (!pt.top && pt.extremum_price < sk.end_pt.extremum_price) {
-                    
-                    sk.end_pt = pt;
+                    self.sks.last_mut().unwrap().end_pt = pt;
+                    // sk.end_pt = pt;
                 }
             } else {
                 // 异向顶底间满足顶比底高，且有独立K线
@@ -74,8 +74,15 @@ impl<'p, 't, T: TradingTimestamps> StrokeShaper<'p, 't, T> {
                                 end_pt: pt,
                             };
                             self.sks.push(new_sk);
+                        } else {
+                            // 当不存在独立K线时，如果超越了当前笔的起始点（高于顶分型或低于底分型）
+                            // 则修改当前笔的前一笔
+                            if self.sks.len() >= 2 && ((pt.top && pt.extremum_price > sk.start_pt.extremum_price) || (!pt.top && pt.extremum_price < sk.start_pt.extremum_price)) {
+                                self.sks.pop().unwrap();
+                                self.sks.last_mut().unwrap().end_pt = pt;
+                            }
                         }
-                    }
+                    } 
                 }
             }
             // 不满足任一成笔条件则丢弃
@@ -204,7 +211,7 @@ mod tests {
         Ok(())
     }
 
-    // 一笔，开盘跳空，3.11 ~ 3.13 贵州茅台
+    // 一笔，开盘跳空，2020.3.11 ~ 2020.3.13 贵州茅台
     // 1. 后底低于前底
     // 2. K线包含
     #[test]
@@ -221,6 +228,34 @@ mod tests {
         assert_eq!(1, sks.len());
         assert_eq!(new_ts("2020-03-11 13:30"), sks[0].start_pt.extremum_ts);
         assert_eq!(new_ts("2020-03-13 10:00"), sks[0].end_pt.extremum_ts);
+        Ok(())
+    }
+
+    // 三笔，2020.2.10 ~ 2020.2.14 贵州茅台
+    // todo
+    #[test]
+    fn test_shaper_three_strokes() -> Result<()> {
+        let sks = pts_to_sks_30_min(vec![
+            ts_pt30("2020-02-10 11:00", 1074.56, true, "2020-02-10 10:30", "2020-02-10 11:30"),
+            ts_pt30("2020-02-10 13:30", 1061.80, false, "2020-02-10 11:30", "2020-02-10 14:00"),
+            ts_pt30("2020-02-10 14:00", 1067.00, true, "2020-02-10 13:30", "2020-02-10 15:00"),
+            ts_pt30("2020-02-10 15:00", 1062.01, false, "2020-02-10 14:00", "2020-02-11 10:00"),
+            ts_pt30("2020-02-11 14:00", 1099.66, true, "2020-02-11 11:00", "2020-02-12 10:00"),
+            ts_pt30("2020-02-12 10:30", 1085.88, false, "2020-02-12 10:00", "2020-02-12 11:00"),
+            ts_pt30("2020-02-12 11:30", 1098.79, true, "2020-02-12 11:00", "2020-02-12 14:00"),
+            ts_pt30("2020-02-12 13:30", 1090.30, false, "2020-02-12 11:30", "2020-02-12 14:30"),
+            ts_pt30("2020-02-13 10:00", 1113.83, true, "2020-02-12 15:00", "2020-02-13 11:00"),
+            ts_pt30("2020-02-13 13:30", 1088.21, false, "2020-02-13 11:30", "2020-02-13 15:00"),
+            ts_pt30("2020-02-13 14:30", 1093.64, true, "2020-02-13 13:30", "2020-02-14 11:00"),
+            ts_pt30("2020-02-14 10:00", 1086.01, false, "2020-02-13 14:30", "2020-02-14 11:30"),
+            ts_pt30("2020-02-14 11:30", 1092.00, true, "2020-02-14 10:00", "2020-02-14 13:30"),
+            ts_pt30("2020-02-14 14:30", 1083.11, false, "2020-02-14 13:30", "2020-02-14 15:00"),
+        ]);
+        assert_eq!(3, sks.len());
+        assert_eq!(new_ts("2020-02-10 11:00"), sks[0].start_pt.extremum_ts);
+        assert_eq!(new_ts("2020-02-10 15:00"), sks[0].end_pt.extremum_ts);
+        assert_eq!(new_ts("2020-02-13 10:00"), sks[1].end_pt.extremum_ts);
+        assert_eq!(new_ts("2020-02-14 14:30"), sks[2].end_pt.extremum_ts);
         Ok(())
     }
 


### PR DESCRIPTION
There are two strokes already, and no indenpendent k line between a new parting and stroke 2,
but price of new parting exceeds the start price of stroke 2 (end price of stroke 1).
In case of this, we need to remove stroke 2, and move end of stroke 1 to new parting.